### PR TITLE
Activate continuous integration

### DIFF
--- a/.github/workflows/deadlink_checker.yml
+++ b/.github/workflows/deadlink_checker.yml
@@ -11,7 +11,8 @@ jobs:
       - name: Link Checker
         uses: peter-evans/link-checker@v1
         with:
-          args: --timeout 60 --document-root index.html aboutme.md contact.md projects.md resume.md
+          # Note that this uses Liche args: https://github.com/raviqqe/liche
+          args: --timeout 60 index.html aboutme.md contact.md projects.md resume.md
 
       - name: Create Issue From File
         uses: peter-evans/create-issue-from-file@v2

--- a/.github/workflows/deadlink_checker.yml
+++ b/.github/workflows/deadlink_checker.yml
@@ -1,0 +1,21 @@
+name: Check markdown links
+on: [push, pull_request]
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Link Checker
+        uses: peter-evans/link-checker@v1
+        with:
+          args: --timeout 60 --document-root index.html aboutme.md contact.md projects.md resume.md
+
+      - name: Create Issue From File
+        uses: peter-evans/create-issue-from-file@v2
+        with:
+          title: Link Checker Report
+          content-filepath: ./link-checker/out.md
+          labels: bug, automated issue

--- a/resume.md
+++ b/resume.md
@@ -3,7 +3,7 @@ layout: page
 title: Resume
 ---
 
-Looking for a printer-friendly version? Click [here](/assets/docs/Ben_Nathanson_Resume_Public.pdf).
+Looking for a printer-friendly version? Click [here](assets/docs/Ben_Nathanson_Resume_Public.pdf).
 
 ---
 


### PR DESCRIPTION
This merge will activate two continuous integration workflows: one for deadlink checking, and another for ensuring that the website is building successfully in the jekyll/builder container. 

As a happy side effect we fixed a potentially buggy link in `resume.md`. 

This resolves issue #1 